### PR TITLE
Send full SAML config

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -11,12 +11,7 @@ module.exports = function (passport, config) {
   });
 
   passport.use(new SamlStrategy(
-    {
-      path: config.passport.saml.path,
-      entryPoint: config.passport.saml.entryPoint,
-      issuer: config.passport.saml.issuer,
-      cert: config.passport.saml.cert
-    },
+    config.passport.saml,
     function (profile, done) {
       return done(null,
         {


### PR DESCRIPTION
Current version only sends a few of the possible configuration
parameters, so any changes to other parameters in config.js are ignored.

This fix addresses this by sending the full saml configuration